### PR TITLE
Upgrade to kali 21.3.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 targets = {
     "pentest" => {
         "box"           => "kalilinux/rolling",
-        "version"       => "2020.2.1",
+        "version"       => "2021.3.0",
         "ip"            => "",
         "reqAudio"      => true,
         "playbooks"     => [

--- a/res/ansible/main.yml
+++ b/res/ansible/main.yml
@@ -22,21 +22,30 @@
     tags:
       - install-update
 
-  - name: Add docker repository
-    apt_repository:
-      repo: deb [arch=amd64] https://download.docker.com/linux/debian buster stable
-      state: present
-      filename: docker
-    tags: 
+  - name: Install docker
+    ansible.builtin.apt:
+      pkg:
+        - docker.io
+      state: latest
+      update_cache: yes
+    tags:
       - install-docker
 
-  - name: Import role ansible-role-docker
-    include_role:
-      name: ansible-role-docker
-      apply:
-        tags:
-          - install-docker
-    tags: 
+  - name: Enable docker on systemd
+    ansible.builtin.systemd:
+      name: docker
+      enabled: yes
+      state: started
+    tags:
+      - install-docker
+
+  - name: Add vagrant to docker group
+    user:
+      name: vagrant
+      groups: docker
+      append: yes
+    become: yes
+    tags:
       - install-docker
 
   - name: Install base packages
@@ -45,27 +54,27 @@
         "{{ packages }}"
       state: latest
       update_cache: yes
-    tags: 
+    tags:
       - install-base-packages
-    
+
   - name: Reboot a machine that might have lots of updates to apply
     reboot:
-      reboot_timeout: 120
-    tags: 
+      reboot_timeout: 3000
+    tags:
       - install-update
       - install-base-packages
 
-  - name: Import role ansible-role-virtualbox-guest
-    include_role:
-      name: ansible-role-virtualbox-guest
-      apply:
-        tags:
-          - install-guest-additions
-    tags: 
-      - install-guest-additions
+  #- name: Import role ansible-role-virtualbox-guest
+  #  include_role:
+  #    name: ansible-role-virtualbox-guest
+  #    apply:
+  #      tags:
+  #        - install-guest-additions
+  #  tags:
+  #    - install-guest-additions
 
-  - name: Reboot for guest OS installation
-    reboot:
-      reboot_timeout: 120
-    tags: 
-      - install-guest-additions
+  #- name: Reboot for guest OS installation
+  #  reboot:
+  #    reboot_timeout: 120
+  #  tags:
+  #    - install-guest-additions

--- a/res/ansible/vars/kali-rolling.yml
+++ b/res/ansible/vars/kali-rolling.yml
@@ -1,4 +1,3 @@
 packages:
-  - burpsuite
   - terminator
   - kmod


### PR DESCRIPTION
# Summary

This PR upgrades Kali image to 21.3.0.
In addition, the following was done:
* Disable VBox role - Kali is now shipped with vbox tools
* Remove burpsuite installation - it's not part of the kali image
* Increase reboot timeout to 30 minutes - sometimes it can take more than 2 minutes.

# Testing done
* Runed full deployment from scratch using `vagrant up`